### PR TITLE
Update auth backend to work with django 1.11

### DIFF
--- a/django_pam/accounts/views.py
+++ b/django_pam/accounts/views.py
@@ -147,7 +147,7 @@ class LoginView(AjaxableResponseMixin, FormView):
         :rtype: dict
         """
         context[self.redirect_field_name] = self.get_success_url()
-        return context
+        return super(LoginView, self).get_context_data(**context)
 
 
 #

--- a/django_pam/auth/backends.py
+++ b/django_pam/auth/backends.py
@@ -45,6 +45,8 @@ class PAMBackend(ModelBackend):
         user = None
 
         if self._pam.authenticate(username, password):
+            # delete "request" if exists in extra_fields
+            extra_fields.pop("request", None)
             try:
                 user = UserModel._default_manager.get_by_natural_key(
                     username=username)


### PR DESCRIPTION
In django 1.11 the request obbject is passed to authenticate method as kwargs, this arg should not be passed to the method that creates the user object.