### PR TITLE
Don't check the type of request parameter as the DRF Request class does not sub the Django HttpRequest class. (fix #6)

### DIFF
--- a/django_pam/auth/backends.py
+++ b/django_pam/auth/backends.py
@@ -48,9 +48,6 @@ class PAMBackend(ModelBackend):
         :type extra_fields: dict
         :rtype: The Django user object or `None` if it fails.
         """
-        assert request is None or isinstance(request, HttpRequest), (
-            "The 'request' positonal argument should be either None or an "
-            "HttpRequest object.")
         UserModel = get_user_model()
         user = None
         service = extra_fields.pop('service', 'login')


### PR DESCRIPTION
Remove unnecessary type check.