### PR TITLE
Use default self.success_url when redirect_field_name is unset

### DIFF
--- a/django_pam/accounts/views.py
+++ b/django_pam/accounts/views.py
@@ -208,7 +208,7 @@ class LogoutView(JSONResponseMixin, TemplateView):
         :rtype: A response object.
         """
         log.debug("request: %s, args: %s, kwargs: %s", request, args, kwargs)
-        next_page = request.POST.get(self.redirect_field_name, '')
+        next_page = request.POST.get(self.redirect_field_name, self.success_url)
         kwargs[self.redirect_field_name] = next_page
         self.success_url = next_page
 


### PR DESCRIPTION
While this change is not applied, self.success_url is useless on logout view.

I'm very new to django, so I don't know if it is a valid bugfix or just a bad patch because it is overwriting anyway the default view value.

Thank you for considering this merge